### PR TITLE
Migrate from recommonmark to myst

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -39,7 +39,13 @@ extensions = [
     "sphinx.ext.imgmath",
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
-    "recommonmark",
+    "myst_parser",
+]
+
+myst_enable_extensions = [
+    "colon_fence",
+    "html_image",
+	"attrs_inline"
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Recommonmark has been deprecated half a decade ago, and myst has features that we could use. (E.g. inline attributes for scaling images in retina distribution.)

Fixes #4.